### PR TITLE
Initialize the DB connection in the backlog thread.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,15 @@ Alternatively, precision use of TTL records for automatic deletion of old cache 
 This project incorporates a backlog to queue changes locally for times when the remote server is unavailable.
 If a `store()` request fails for any reason, it can be cached in the backlog to be committed later.
 In memcached this data would be lost or require the application to wait until the server returned.
-This is well-suited to asynchronous producer/consumer applications where the producer doesn't want to wait around
-for the server to become available and it is okay if the consumer gets the data eventually.
+ValuStor's behavior is well-suited to asynchronous producer/consumer applications where the producer doesn't
+want to wait around for the server to become available and it is okay if the consumer gets the data eventually.
 It's another layer of redundancy on top of an already solid database backend.
 
 Backlog use is optional and its use can be selected individually for each `store()` request.
+The default backlog mode can be set in the initial configuration.
 
-In order to maximize performance of the store functionality by using a (nearly) lockless design,
-a few design trade-offs were made:
-1. The backlog won't remove the older of multiple entries with the same key. This slightly reduces backlog performance.
-2. `retrieve()` does not check the backlog.
-3. If the client cannot connect to a server and never has, failed `store()` calls will use the backlog queue.
-   Even if the server becomes accessible, the backlog thread will not begin to process automatically.
-   The backlog processing will only being once the first `store()` call is successful.
+In order to maximize performance of the store functionality, the backlog won't remove the older of multiple entries with the same key.
+This slightly reduces backlog performance. Similarly, `retrieve()` maximizes performance by not checking the backlog.
 
 ## Consistencies
 In many traditional synchronized database clusters any writes are guaranteed to be available by a quorum of nodes 

--- a/ValuStor.hpp
+++ b/ValuStor.hpp
@@ -1,7 +1,7 @@
 /*
 ValuStor - Scylla DB key-value pair storage
 
-version 1.0.0-rc2
+version 1.0.0-rc3
 
 Licensed under the MIT License
 
@@ -218,7 +218,6 @@ class ValuStor
     std::map<size_t, const CassPrepared*> prepared_selects;
 
     std::atomic<bool> is_initialized;
-    std::mutex initialization_mutex;
     std::thread backlog_thread;
     InsertMode_t default_backlog_mode;
     std::vector<CassConsistency> read_consistencies;
@@ -451,15 +450,22 @@ class ValuStor
     } // configure()
 
     // ****************************************************************************************************
-    /// @name            initialize
+    /// @name            run_backlog_thread
     ///
-    /// @brief           Initialize the connection given a valid CassCluster* already setup.
+    /// @brief           Run the backlog thread.
     ///
-    void initialize(void){
+    void run_backlog_thread(void){
       //
-      // Only initialize once.
+      // Start the backlog thread
       //
-      if(not this->is_initialized){
+      std::atomic<bool> are_pointers_setup(false);
+
+      // *****************************************************************************
+      /// @name           initialize
+      ///
+      /// @brief          Initialize the connection given a valid CassCluster* already setup.
+      ///
+      auto initialize = [&](void){
         this->session = cass_session_new();
         CassFuture* connect_future = cass_session_connect(this->session, cluster);
         if(connect_future != nullptr){
@@ -548,21 +554,14 @@ class ValuStor
               this->session = nullptr;
             }
           }
-        }
-      }
-    } // initialize
+        }        
+      };
 
-    // ****************************************************************************************************
-    /// @name            run_backlog_thread
-    ///
-    /// @brief           Run the backlog thread.
-    ///
-    void run_backlog_thread(void){
-      //
-      // Start the backlog thread
-      //
-      std::atomic<bool> are_pointers_setup(false);
-
+      // *****************************************************************************
+      /// @name           backlog_thread
+      ///
+      /// @brief          The backlog thread handles initializing the connection and manages the backlog queue.
+      ///
       this->backlog_thread = std::thread([&](void){
         //
         // Setup the pointers back to the master thread.
@@ -595,13 +594,20 @@ class ValuStor
         // "do_terminate_thread" must be set first.
         // Once initialization takes place, we never need to access it again.
         //
+        initialize();
         while(not do_terminate_thread and not this->is_initialized){
           try{
             std::this_thread::sleep_for(std::chrono::seconds(1));
+            initialize();
           }
           catch(...){}
         }
         *is_processing_backlog = false;
+
+        //
+        // Try to initialize
+        //
+
         while(not do_terminate_thread){
           try{
             std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -719,12 +725,7 @@ class ValuStor
       this->configure();
 
       //
-      // Initialize the connection
-      //
-      this->initialize();
-
-      //
-      // Start the backlog thread
+      // Start the backlog thread (which will perform initialization)
       //
       this->run_backlog_thread();
     }
@@ -772,12 +773,7 @@ class ValuStor
       this->configure();
 
       //
-      // Initialize the connection
-      //
-      this->initialize();
-
-      //
-      // Start the backlog thread
+      // Start the backlog thread (which will perform initialization)
       //
       this->run_backlog_thread();
     }
@@ -858,20 +854,16 @@ class ValuStor
     /// @return          If 'result.first', the string value in 'result.second', otherwise not found.
     ///
     ValuStor::Result retrieve(Keys... keys, size_t count = 0){
-      //
-      // Make sure we are initialized
-      //
-      if(not this->is_initialized){
-        std::lock_guard<std::mutex> lock(initialization_mutex);
-        this->initialize(); // Only one thread at a time can try to initialize. Once successful store.is_initialized is set.
-      }
-
       ErrorCode_t error_code = UNKNOWN_ERROR;
       std::string error_message = "Scylla Error";
 
       std::vector<std::pair<Val_T, std::tuple<Keys...>>> retrieved_data;
 
-      if(this->prepared_selects.size() == 0){
+      if(not this->is_initialized){
+        error_code = SESSION_FAILED;
+        error_message = "Scylla Error: Could not connect to server(s)";
+      }
+      else if(this->prepared_selects.size() == 0){
         error_code = PREPARED_SELECT_FAILED;
         error_message = "Scylla Error: Prepared Select Failed";
       }
@@ -1008,13 +1000,6 @@ class ValuStor
                            int32_t seconds_ttl = 0,
                            InsertMode_t insert_mode = DEFAULT_BACKLOG_MODE,
                            int64_t insert_microseconds_since_epoch = 0){
-      //
-      // Make sure we are initialized
-      //
-      if(not this->is_initialized){
-        std::lock_guard<std::mutex> lock(initialization_mutex);
-        this->initialize(); // Only one thread at a time can try to initialize. Once successful store.is_initialized is set.
-      }
 
       if(insert_mode == DEFAULT_BACKLOG_MODE){
         insert_mode = this->default_backlog_mode;
@@ -1033,6 +1018,10 @@ class ValuStor
         }
         error_code = SUCCESS;
         error_message = "Backlogged";
+      }
+      else if(not this->is_initialized){
+        error_code = SESSION_FAILED;
+        error_message = "Scylla Error: Could not connect to server(s)";
       }
       else if(this->prepared_insert == nullptr){
         error_code = PREPARED_INSERT_FAILED;

--- a/ValuStor.hpp
+++ b/ValuStor.hpp
@@ -603,11 +603,6 @@ class ValuStor
           catch(...){}
         }
         *is_processing_backlog = false;
-
-        //
-        // Try to initialize
-        //
-
         while(not do_terminate_thread){
           try{
             std::this_thread::sleep_for(std::chrono::seconds(2));


### PR DESCRIPTION
Initialize the DB connection in the backlog thread.

The database connection initialization is now done by the backlog thread.
This fixes the issue where values could get stuck in the backlog.
This change allows us to remove a mutex from the code and replace it with polling an atomic instead.
This fixes "Fix backlog limitation." (#8)

Fixed a pointer initialization race condition.
On x64 platforms these writes are inherently atomic, but this would have broken portability.
Calls to store() and retrieve() no longer block on an uninitialized state.
Instead, the calls fail immediately. In the case of store() where the backlog is used, the requests are immediately added to the backlog queue.
This should improve the performance of these functions and prevent them from blocking before the initialization completes.
This fixes "Race condition on init failure." (#9)